### PR TITLE
Add support for "Segments" (and Segment-ACK)

### DIFF
--- a/src/application_protocol/application_pdu.rs
+++ b/src/application_protocol/application_pdu.rs
@@ -4,7 +4,7 @@ use crate::common::{
 };
 
 use super::{
-    confirmed::{ComplexAck, ConfirmedBacnetError, ConfirmedRequest, SimpleAck},
+    confirmed::{ComplexAck, ConfirmedBacnetError, ConfirmedRequest, SegmentAck, SimpleAck},
     segment::Segment,
     unconfirmed::UnconfirmedRequest,
 };
@@ -19,6 +19,7 @@ pub enum ApplicationPdu<'a> {
     SimpleAck(SimpleAck),
     Error(ConfirmedBacnetError),
     Segment(Segment<'a>),
+    SegmentAck(SegmentAck),
     // add more here (see ApduType)
 }
 
@@ -127,8 +128,9 @@ impl<'a> ApplicationPdu<'a> {
             Self::UnconfirmedRequest(req) => req.encode(writer),
             Self::ComplexAck(req) => req.encode(writer),
             Self::SimpleAck(ack) => ack.encode(writer),
+            Self::SegmentAck(ack) => ack.encode(writer),
+            Self::Segment(segment) => segment.encode(writer),
             Self::Error(_) => todo!(),
-            Self::Segment(_) => todo!(),
         };
     }
 
@@ -162,6 +164,10 @@ impl<'a> ApplicationPdu<'a> {
             ApduType::SimpleAck => {
                 let adpu = SimpleAck::decode(reader, buf)?;
                 Ok(Self::SimpleAck(adpu))
+            }
+            ApduType::SegmentAck => {
+                let adpu = SegmentAck::decode(reader, buf)?;
+                Ok(Self::SegmentAck(adpu))
             }
             ApduType::Error => {
                 let apdu = ConfirmedBacnetError::decode(reader, buf)?;

--- a/src/application_protocol/application_pdu.rs
+++ b/src/application_protocol/application_pdu.rs
@@ -4,7 +4,8 @@ use crate::common::{
 };
 
 use super::{
-    confirmed::{ConfirmedBacnetError, ComplexAck, ConfirmedRequest, SimpleAck},
+    confirmed::{ComplexAck, ConfirmedBacnetError, ConfirmedRequest, SimpleAck},
+    segment::Segment,
     unconfirmed::UnconfirmedRequest,
 };
 
@@ -17,10 +18,11 @@ pub enum ApplicationPdu<'a> {
     ComplexAck(ComplexAck<'a>),
     SimpleAck(SimpleAck),
     Error(ConfirmedBacnetError),
+    Segment(Segment<'a>),
     // add more here (see ApduType)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
@@ -126,6 +128,7 @@ impl<'a> ApplicationPdu<'a> {
             Self::ComplexAck(req) => req.encode(writer),
             Self::SimpleAck(ack) => ack.encode(writer),
             Self::Error(_) => todo!(),
+            Self::Segment(_) => todo!(),
         };
     }
 
@@ -134,12 +137,13 @@ impl<'a> ApplicationPdu<'a> {
         let pdu_type: ApduType = (byte0 >> 4).try_into()?;
         let pdu_flags = byte0 & 0x0F;
         let segmented_message = (pdu_flags & PduFlags::SegmentedMessage as u8) > 0;
-        let _more_follows = (pdu_flags & PduFlags::MoreFollows as u8) > 0;
+        let more_follows = (pdu_flags & PduFlags::MoreFollows as u8) > 0;
         let _segmented_response_accepted =
             (pdu_flags & PduFlags::SegmentedResponseAccepted as u8) > 0;
 
         if segmented_message {
-            return Err(Error::SegmentationNotSupported);
+            let segment = Segment::decode(more_follows, pdu_type, reader, buf)?;
+            return Ok(Self::Segment(segment));
         }
 
         match pdu_type {

--- a/src/application_protocol/confirmed.rs
+++ b/src/application_protocol/confirmed.rs
@@ -385,7 +385,7 @@ impl<'a> ComplexAckService<'a> {
                 Ok(ComplexAckService::ReadRange(service))
             }
             s => {
-                return Err(Error::Unimplemented(Unimplemented::ConfirmedServiceChoice(
+                Err(Error::Unimplemented(Unimplemented::ConfirmedServiceChoice(
                     s,
                 )))
             }
@@ -428,7 +428,7 @@ impl<'a> ConfirmedRequestService<'a> {
                 Ok(ConfirmedRequestService::WriteProperty(service))
             }
             s => {
-                return Err(Error::Unimplemented(Unimplemented::ConfirmedServiceChoice(
+                Err(Error::Unimplemented(Unimplemented::ConfirmedServiceChoice(
                     s,
                 )))
             }

--- a/src/application_protocol/mod.rs
+++ b/src/application_protocol/mod.rs
@@ -1,5 +1,6 @@
 pub mod application_pdu;
 pub mod confirmed;
 pub mod primitives;
+pub mod segment;
 pub mod services;
 pub mod unconfirmed;

--- a/src/application_protocol/segment.rs
+++ b/src/application_protocol/segment.rs
@@ -1,3 +1,5 @@
+use core::usize;
+
 use crate::common::{error::Error, io::{Reader, Writer}};
 
 use super::application_pdu::{ApduType, PduFlags};
@@ -56,11 +58,18 @@ impl<'a> Segment<'a> {
 
     // a special case encoder for when this segment is being accumulated
     // into an unsegmented APDU.
-    pub fn encode_for_accumulation(&self, writer: &mut Writer) {
-        if self.invoke_id == 0 {
-            writer.push(self.apdu_type.clone() as u8);
+    pub fn encode_for_accumulation(&self, writer: &mut Writer) -> usize {
+        let mut written = 0;
+        if self.sequence_number == 0 {
+            writer.push((self.apdu_type.clone() as u8) << 4);
+            writer.push(self.invoke_id);
+            writer.push(self.service_choice);
+            written += 3;
         }
         writer.extend_from_slice(self.data);
+        written += self.data.len();
+        
+        written
     }
 }
 

--- a/src/application_protocol/segment.rs
+++ b/src/application_protocol/segment.rs
@@ -1,20 +1,15 @@
-use crate::common::{error::Error, io::Reader};
+use crate::common::{error::Error, io::{Reader, Writer}};
 
-use super::{
-    application_pdu::{ApduType, MaxAdpu, MaxSegments},
-    confirmed::{ComplexAckService, ConfirmedRequestService, ConfirmedServiceChoice},
-};
+use super::application_pdu::{ApduType, PduFlags};
 
 #[derive(Debug, Clone)]
 pub struct Segment<'a> {
     pub apdu_type: ApduType,
     pub more_follows: bool,
-    pub max_response_segments: MaxSegments,
-    pub max_apdu_size: MaxAdpu,
 
     pub invoke_id: u8,
     pub sequence_number: u8,
-    pub proposed_window_size: u8, // number of segments before an Segment-ACK must be sent
+    pub window_size: u8, // number of segments before an Segment-ACK must be sent
     pub service_choice: u8,
 
     // apdu data
@@ -28,116 +23,76 @@ impl<'a> Segment<'a> {
         reader: &mut Reader,
         buf: &'a [u8],
     ) -> Result<Self, Error> {
-        let byte0 = reader.read_byte(buf)?;
-        let max_segments: MaxSegments = (byte0 & 0xF0).into();
-        let max_adpu: MaxAdpu = (byte0 & 0x0F).into();
         let invoke_id = reader.read_byte(buf)?;
         let sequence_number = reader.read_byte(buf)?;
-        let proposed_window_size = reader.read_byte(buf)?;
+        let window_size = reader.read_byte(buf)?;
         let service_choice = reader.read_byte(buf)?;
 
         Ok(Segment {
             apdu_type,
             more_follows,
-            max_response_segments: max_segments,
-            max_apdu_size: max_adpu,
 
             invoke_id,
             sequence_number,
-            proposed_window_size,
+            window_size,
             service_choice,
 
-            data: buf,
+            data: &buf[reader.index..],
         })
     }
+
+    pub fn encode(&self, writer: &mut Writer) {
+        let mut control = ((self.apdu_type.clone() as u8) << 4) | PduFlags::SegmentedMessage as u8;
+        if self.more_follows {
+            control = control | PduFlags::MoreFollows as u8;
+        }
+        writer.push(control);
+        writer.push(self.invoke_id);
+        writer.push(self.sequence_number);
+        writer.push(self.window_size);
+        writer.push(self.service_choice);
+        writer.extend_from_slice(self.data);
+    }
+
+    // a special case encoder for when this segment is being accumulated
+    // into an unsegmented APDU.
+    pub fn encode_for_accumulation(&self, writer: &mut Writer) {
+        if self.invoke_id == 0 {
+            writer.push(self.apdu_type.clone() as u8);
+        }
+        writer.extend_from_slice(self.data);
+    }
 }
 
-pub enum CombinedSegments<'a> {
-    ConfirmedRequest(u8, ConfirmedRequestService<'a>),
-    ComplexAck(u8, ComplexAckService<'a>),
-}
+#[cfg(test)]
+mod tests {
+    use crate::{application_protocol::application_pdu::ApduType, common::io::{Reader, Writer}};
 
-// combine and decode a number of segments into it's service.
-pub fn decode<'a>(buf: &'a mut [u8], segments: &[Segment]) -> Result<CombinedSegments<'a>, Error> {
-    if segments.is_empty() {
-        return Err(Error::InvalidValue("no segments to decode"));
+    use super::Segment;
+ 
+    #[test]
+    fn reversable() {
+        // decoding
+        let input: [u8; 7] = [60,1,0,1,1,2,3];
+        let mut reader = Reader::new_with_len(input.len() - 1);
+        let decoded = Segment::decode(true, ApduType::ComplexAck, &mut reader, &input[1..]).unwrap();
+       
+        // encoding
+        let mut output: [u8; 7] = [0; 7];
+        let mut writer = Writer::new(&mut output);
+        decoded.encode(&mut writer);
+        assert_eq!(input, output);
     }
-
-    // TODO: combine all these iterations into one.
-    let first_segment = &segments[0];
-    if !segments
-        .iter()
-        .all(|segment| segment.apdu_type == first_segment.apdu_type)
-    {
-        return Err(Error::InvalidValue(
-            "not all segments have matching apdu type",
-        ));
-    }
-    if !segments
-        .iter()
-        .all(|segment| segment.service_choice == first_segment.service_choice)
-    {
-        return Err(Error::InvalidValue(
-            "not all segments have matching apdu service choice",
-        ));
-    }
-    if !segments
-        .iter()
-        .all(|segment| segment.invoke_id == first_segment.invoke_id)
-    {
-        return Err(Error::InvalidValue(
-            "not all segments have matching invoke id",
-        ));
-    }
-
-    // copy segments into buffer including bounds checking
-    let total_len: usize = segments.iter().map(|segment| segment.data.len()).sum();
-    if total_len > buf.len() {
-        return Err(Error::Length((
-            "buf not large enough to combine all segments",
-            total_len as u32,
-        )));
-    }
-
-    let mut dest_iter = buf.iter_mut();
-    for segment in segments.iter().map(|segment| segment.data) {
-        for &byte in segment {
-            if let Some(dest_slot) = dest_iter.next() {
-                *dest_slot = byte;
-            }
-        }
-    }
-
-    let mut reader = Reader::new_with_len(total_len);
-    match first_segment.apdu_type {
-        ApduType::ConfirmedServiceRequest => {
-            let choice: ConfirmedServiceChoice =
-                first_segment.service_choice.try_into().map_err(|e| {
-                    Error::InvalidVariant((
-                        "ConfirmedRequest decode ConfirmedServiceChoice",
-                        e as u32,
-                    ))
-                })?;
-            let service = ConfirmedRequestService::decode(choice, &mut reader, buf)?;
-            Ok(CombinedSegments::ConfirmedRequest(
-                first_segment.invoke_id,
-                service,
-            ))
-        }
-        ApduType::ComplexAck => {
-            let choice: ConfirmedServiceChoice =
-                first_segment.service_choice.try_into().map_err(|e| {
-                    Error::InvalidVariant((
-                        "ConfirmedRequest decode ConfirmedServiceChoice",
-                        e as u32,
-                    ))
-                })?;
-            let service = ComplexAckService::decode(choice, &mut reader, buf)?;
-            Ok(CombinedSegments::ComplexAck(
-                first_segment.invoke_id,
-                service,
-            ))
-        }
-        _ => unimplemented!(),
+    
+    #[test]
+    fn decoding() {
+        // decoding
+        let input: [u8; 6] = [1,12,1,1,2,3];
+        let mut reader = Reader::new_with_len(input.len());
+        let decoded = Segment::decode(false, ApduType::ComplexAck, &mut reader, &input).unwrap(); 
+        assert_eq!(decoded.more_follows, false);
+        assert_eq!(decoded.sequence_number, 12);
+        assert_eq!(decoded.window_size, 1);
+        assert_eq!(decoded.apdu_type, ApduType::ComplexAck);
     }
 }

--- a/src/application_protocol/segment.rs
+++ b/src/application_protocol/segment.rs
@@ -59,34 +59,31 @@ pub enum CombinedSegments<'a> {
 
 // combine and decode a number of segments into it's service.
 pub fn decode<'a>(buf: &'a mut [u8], segments: &[Segment]) -> Result<CombinedSegments<'a>, Error> {
-    if segments.len() == 0 {
+    if segments.is_empty() {
         return Err(Error::InvalidValue("no segments to decode"));
     }
 
     // TODO: combine all these iterations into one.
     let first_segment = &segments[0];
-    if segments
+    if !segments
         .iter()
         .all(|segment| segment.apdu_type == first_segment.apdu_type)
-        == false
     {
         return Err(Error::InvalidValue(
             "not all segments have matching apdu type",
         ));
     }
-    if segments
+    if !segments
         .iter()
         .all(|segment| segment.service_choice == first_segment.service_choice)
-        == false
     {
         return Err(Error::InvalidValue(
             "not all segments have matching apdu service choice",
         ));
     }
-    if segments
+    if !segments
         .iter()
         .all(|segment| segment.invoke_id == first_segment.invoke_id)
-        == false
     {
         return Err(Error::InvalidValue(
             "not all segments have matching invoke id",

--- a/src/application_protocol/segment.rs
+++ b/src/application_protocol/segment.rs
@@ -1,0 +1,146 @@
+use crate::common::{error::Error, io::Reader};
+
+use super::{
+    application_pdu::{ApduType, MaxAdpu, MaxSegments},
+    confirmed::{ComplexAckService, ConfirmedRequestService, ConfirmedServiceChoice},
+};
+
+#[derive(Debug, Clone)]
+pub struct Segment<'a> {
+    pub apdu_type: ApduType,
+    pub more_follows: bool,
+    pub max_response_segments: MaxSegments,
+    pub max_apdu_size: MaxAdpu,
+
+    pub invoke_id: u8,
+    pub sequence_number: u8,
+    pub proposed_window_size: u8, // number of segments before an Segment-ACK must be sent
+    pub service_choice: u8,
+
+    // apdu data
+    pub data: &'a [u8],
+}
+
+impl<'a> Segment<'a> {
+    pub fn decode(
+        more_follows: bool,
+        apdu_type: ApduType,
+        reader: &mut Reader,
+        buf: &'a [u8],
+    ) -> Result<Self, Error> {
+        let byte0 = reader.read_byte(buf)?;
+        let max_segments: MaxSegments = (byte0 & 0xF0).into();
+        let max_adpu: MaxAdpu = (byte0 & 0x0F).into();
+        let invoke_id = reader.read_byte(buf)?;
+        let sequence_number = reader.read_byte(buf)?;
+        let proposed_window_size = reader.read_byte(buf)?;
+        let service_choice = reader.read_byte(buf)?;
+
+        Ok(Segment {
+            apdu_type,
+            more_follows,
+            max_response_segments: max_segments,
+            max_apdu_size: max_adpu,
+
+            invoke_id,
+            sequence_number,
+            proposed_window_size,
+            service_choice,
+
+            data: buf,
+        })
+    }
+}
+
+pub enum CombinedSegments<'a> {
+    ConfirmedRequest(u8, ConfirmedRequestService<'a>),
+    ComplexAck(u8, ComplexAckService<'a>),
+}
+
+// combine and decode a number of segments into it's service.
+pub fn decode<'a>(buf: &'a mut [u8], segments: &[Segment]) -> Result<CombinedSegments<'a>, Error> {
+    if segments.len() == 0 {
+        return Err(Error::InvalidValue("no segments to decode"));
+    }
+
+    // TODO: combine all these iterations into one.
+    let first_segment = &segments[0];
+    if segments
+        .iter()
+        .all(|segment| segment.apdu_type == first_segment.apdu_type)
+        == false
+    {
+        return Err(Error::InvalidValue(
+            "not all segments have matching apdu type",
+        ));
+    }
+    if segments
+        .iter()
+        .all(|segment| segment.service_choice == first_segment.service_choice)
+        == false
+    {
+        return Err(Error::InvalidValue(
+            "not all segments have matching apdu service choice",
+        ));
+    }
+    if segments
+        .iter()
+        .all(|segment| segment.invoke_id == first_segment.invoke_id)
+        == false
+    {
+        return Err(Error::InvalidValue(
+            "not all segments have matching invoke id",
+        ));
+    }
+
+    // copy segments into buffer including bounds checking
+    let total_len: usize = segments.iter().map(|segment| segment.data.len()).sum();
+    if total_len > buf.len() {
+        return Err(Error::Length((
+            "buf not large enough to combine all segments",
+            total_len as u32,
+        )));
+    }
+
+    let mut dest_iter = buf.iter_mut();
+    for segment in segments.iter().map(|segment| segment.data) {
+        for &byte in segment {
+            if let Some(dest_slot) = dest_iter.next() {
+                *dest_slot = byte;
+            }
+        }
+    }
+
+    let mut reader = Reader::new_with_len(total_len);
+    match first_segment.apdu_type {
+        ApduType::ConfirmedServiceRequest => {
+            let choice: ConfirmedServiceChoice =
+                first_segment.service_choice.try_into().map_err(|e| {
+                    Error::InvalidVariant((
+                        "ConfirmedRequest decode ConfirmedServiceChoice",
+                        e as u32,
+                    ))
+                })?;
+            let service = ConfirmedRequestService::decode(choice, &mut reader, buf)?;
+            Ok(CombinedSegments::ConfirmedRequest(
+                first_segment.invoke_id,
+                service,
+            ))
+        }
+        ApduType::ComplexAck => {
+            let choice: ConfirmedServiceChoice =
+                first_segment.service_choice.try_into().map_err(|e| {
+                    Error::InvalidVariant((
+                        "ConfirmedRequest decode ConfirmedServiceChoice",
+                        e as u32,
+                    ))
+                })?;
+            let service = ComplexAckService::decode(choice, &mut reader, buf)?;
+            Ok(CombinedSegments::ComplexAck(
+                first_segment.invoke_id,
+                service,
+            ))
+        }
+        _ => unimplemented!(),
+    }
+}


### PR DESCRIPTION
Segments are partially decoded APDUs that include sufficient information for the application to buffer/accumulate into a non-segmented APDU. The include information like invoke_id, sequence number, if more segments are to follow, window size, etc.

This is a first pass. The new "Segment" struct may be unnecessary - instead just implementing `encode_for_accumulation` on each service choice may be sufficient. TBC as my app matures.