### PR TITLE
Include reference to raw child packet in DataLink and NPDU.

### DIFF
--- a/src/network_protocol/network_pdu.rs
+++ b/src/network_protocol/network_pdu.rs
@@ -15,6 +15,8 @@ pub struct NetworkPdu<'a> {
     pub expect_reply: bool,
     pub message_priority: MessagePriority,
     pub network_message: NetworkMessage<'a>,
+
+    pub raw_payload: &'a [u8],
 }
 
 // NOTE: this is actually a control flag
@@ -135,6 +137,7 @@ impl<'a> NetworkPdu<'a> {
             expect_reply,
             message_priority,
             network_message: message,
+            raw_payload: &[], // empty unless decoding
         }
     }
 
@@ -239,6 +242,7 @@ impl<'a> NetworkPdu<'a> {
             None
         };
 
+        let payload_start_index = reader.index;
         let network_message = if is_network_message {
             let message_type = reader.read_byte(buf)?;
             match message_type.try_into() {
@@ -256,6 +260,7 @@ impl<'a> NetworkPdu<'a> {
             expect_reply,
             message_priority,
             network_message,
+            raw_payload: &buf[payload_start_index..],
         })
     }
 }


### PR DESCRIPTION
### Why?

My app implements a state machine to model confirmed requests. To support segmented requests this state machine accumulates the first APDU, and then for every following segment, just the "data".

When all segments have been recieved I combine them all (`APDU + data + data`) and send them to the application for decoding (and use).

I'd like to use the same state machine for non segmented APDUs.

Ideally I'd be able to easily get a slice of the buffer that represents the APDU during reading, but given `ApplicationPdu` is implemented as an enum this isn't currently possible.

### What?

I've updated NetworkPdu and DataLink to include references to their raw payloads when decoding.
