### PR TITLE
Add ApplicationDataValueWrite::SignedInt and UnsignedInt variants.

### DIFF
--- a/examples/learn_controller.rs
+++ b/examples/learn_controller.rs
@@ -149,7 +149,7 @@ pub struct ScheduleValue {
 pub struct TrendLogValue {
     pub id: ObjectId,
     pub name: String,
-    pub record_count: u32,
+    pub record_count: u64,
 }
 
 #[cfg(feature = "alloc")]

--- a/src/application_protocol/primitives/data_value.rs
+++ b/src/application_protocol/primitives/data_value.rs
@@ -3,7 +3,7 @@ use core::{fmt::Display, str::from_utf8};
 use crate::common::{
     daily_schedule::WeeklySchedule,
     error::Error,
-    helper::{decode_unsigned, encode_application_enumerated},
+    helper::{decode_signed, decode_unsigned, encode_application_enumerated, encode_application_signed, encode_application_unsigned},
     io::{Reader, Writer},
     object_id::{ObjectId, ObjectType},
     property_id::PropertyId,
@@ -31,7 +31,8 @@ pub enum ApplicationDataValue<'a> {
     CharacterString(CharacterString<'a>),
     Enumerated(Enumerated),
     BitString(BitString<'a>),
-    UnsignedInt(u32),
+    UnsignedInt(u64),
+    SignedInt(i64),
     WeeklySchedule(WeeklySchedule<'a>),
 }
 
@@ -39,8 +40,8 @@ pub enum ApplicationDataValue<'a> {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ApplicationDataValueWrite<'a> {
     Boolean(bool),
-    SignedInt(i32),
-    UnsignedInt(u32),
+    UnsignedInt(u64),
+    SignedInt(i64),
     Enumerated(Enumerated),
     Real(f32),
     WeeklySchedule(WeeklySchedule<'a>),
@@ -375,24 +376,18 @@ impl<'a> ApplicationDataValueWrite<'a> {
                         Ok(Self::Enumerated(value))
                     }
                     TagNumber::Application(ApplicationTagNumber::UnsignedInt) => {
-                        let len = tag.value as usize;
-                        if len > 4 {
-                            return Err(Error::Length(("integers longer than 4 bytes are not supported", tag.value)));
-                        }
-                        let mut bytes = [0; 4];
-                        bytes[..len].copy_from_slice(reader.read_slice(len, buf)?);
-                        let value = u32::from_be_bytes(bytes) >> (8 * (4 - len));
-                        Ok(Self::UnsignedInt(value))
+                        Ok(Self::UnsignedInt(decode_unsigned(tag.value, reader, buf)?))
 
                     }
                     TagNumber::Application(ApplicationTagNumber::SignedInt) => {
                         let len = tag.value as usize;
-                        if len > 4 {
-                            return Err(Error::Length(("integers longer than 4 bytes are not supported", tag.value)));
+                        if len > 8 {
+                            return Err(Error::Length(("integers bigger than 64 bits are not supported", tag.value)));
                         }
-                        let mut bytes = [0; 4];
+                        // Read into the most significant bits, then do a right shift to get sign extension for negative integers.
+                        let mut bytes = [0; 8];
                         bytes[..len].copy_from_slice(reader.read_slice(len, buf)?);
-                        let value = i32::from_be_bytes(bytes) >> (8 * (4 - len));
+                        let value = i64::from_be_bytes(bytes) >> (8 * (8 - len));
                         Ok(Self::SignedInt(value))
 
                     }
@@ -421,22 +416,10 @@ impl<'a> ApplicationDataValueWrite<'a> {
                 writer.extend_from_slice(&f32::to_be_bytes(*x))
             }
             Self::UnsignedInt(x) => {
-                let data = x.to_be_bytes();
-                let skip = data.into_iter().take_while(|&x| x == 0).count();
-                let data = &data[skip..];
-                Tag::new(TagNumber::Application(ApplicationTagNumber::UnsignedInt), data.len() as u32)
-                    .encode(writer);
-                writer.extend_from_slice(data);
+                encode_application_unsigned(writer, *x);
             }
             Self::SignedInt(x) => {
-                let data = x.to_be_bytes();
-                let leading_zeros = data.into_iter().take_while(|&x| x == 0).count();
-                let leading_ones = data.into_iter().take_while(|&x| x == 0xFF).count();
-                let skip = usize::max(leading_zeros, leading_ones);
-                let data = &data[skip..];
-                Tag::new(TagNumber::Application(ApplicationTagNumber::SignedInt), data.len() as u32)
-                    .encode(writer);
-                writer.extend_from_slice(data);
+                encode_application_signed(writer, *x);
             }
             Self::Enumerated(x) => {
                 x.encode(writer);
@@ -499,9 +482,10 @@ impl<'a> ApplicationDataValue<'a> {
                 x.encode_application(writer);
             }
             ApplicationDataValue::UnsignedInt(x) => {
-                Tag::new(TagNumber::Application(ApplicationTagNumber::UnsignedInt), 4)
-                    .encode(writer);
-                writer.extend_from_slice(&x.to_be_bytes());
+                encode_application_unsigned(writer, *x)
+            }
+            ApplicationDataValue::SignedInt(x) => {
+                encode_application_signed(writer, *x)
             }
             ApplicationDataValue::WeeklySchedule(x) => {
                 // no application tag required for weekly schedule
@@ -563,8 +547,12 @@ impl<'a> ApplicationDataValue<'a> {
                 Ok(ApplicationDataValue::Boolean(value))
             }
             ApplicationTagNumber::UnsignedInt => {
-                let value = decode_unsigned(tag.value, reader, buf)? as u32;
+                let value = decode_unsigned(tag.value, reader, buf)?;
                 Ok(ApplicationDataValue::UnsignedInt(value))
+            }
+            ApplicationTagNumber::SignedInt => {
+                let value = decode_signed(tag.value, reader, buf)?;
+                Ok(ApplicationDataValue::SignedInt(value))
             }
             ApplicationTagNumber::Time => {
                 if tag.value != 4 {

--- a/src/application_protocol/primitives/data_value.rs
+++ b/src/application_protocol/primitives/data_value.rs
@@ -39,6 +39,8 @@ pub enum ApplicationDataValue<'a> {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ApplicationDataValueWrite<'a> {
     Boolean(bool),
+    SignedInt(i32),
+    UnsignedInt(u32),
     Enumerated(Enumerated),
     Real(f32),
     WeeklySchedule(WeeklySchedule<'a>),
@@ -372,6 +374,28 @@ impl<'a> ApplicationDataValueWrite<'a> {
                         let value = decode_enumerated(object_id, property_id, &tag, reader, buf)?;
                         Ok(Self::Enumerated(value))
                     }
+                    TagNumber::Application(ApplicationTagNumber::UnsignedInt) => {
+                        let len = tag.value as usize;
+                        if len > 4 {
+                            return Err(Error::Length(("integers longer than 4 bytes are not supported", tag.value)));
+                        }
+                        let mut bytes = [0; 4];
+                        bytes[..len].copy_from_slice(reader.read_slice(len, buf)?);
+                        let value = u32::from_be_bytes(bytes) >> (8 * (4 - len));
+                        Ok(Self::UnsignedInt(value))
+
+                    }
+                    TagNumber::Application(ApplicationTagNumber::SignedInt) => {
+                        let len = tag.value as usize;
+                        if len > 4 {
+                            return Err(Error::Length(("integers longer than 4 bytes are not supported", tag.value)));
+                        }
+                        let mut bytes = [0; 4];
+                        bytes[..len].copy_from_slice(reader.read_slice(len, buf)?);
+                        let value = i32::from_be_bytes(bytes) >> (8 * (4 - len));
+                        Ok(Self::SignedInt(value))
+
+                    }
                     tag_number => Err(Error::TagNotSupported((
                         "ApplicationDataValueWrite decode",
                         tag_number,
@@ -395,6 +419,24 @@ impl<'a> ApplicationDataValueWrite<'a> {
                 let tag = Tag::new(TagNumber::Application(ApplicationTagNumber::Real), len);
                 tag.encode(writer);
                 writer.extend_from_slice(&f32::to_be_bytes(*x))
+            }
+            Self::UnsignedInt(x) => {
+                let data = x.to_be_bytes();
+                let skip = data.into_iter().take_while(|&x| x == 0).count();
+                let data = &data[skip..];
+                Tag::new(TagNumber::Application(ApplicationTagNumber::UnsignedInt), data.len() as u32)
+                    .encode(writer);
+                writer.extend_from_slice(data);
+            }
+            Self::SignedInt(x) => {
+                let data = x.to_be_bytes();
+                let leading_zeros = data.into_iter().take_while(|&x| x == 0).count();
+                let leading_ones = data.into_iter().take_while(|&x| x == 0xFF).count();
+                let skip = usize::max(leading_zeros, leading_ones);
+                let data = &data[skip..];
+                Tag::new(TagNumber::Application(ApplicationTagNumber::SignedInt), data.len() as u32)
+                    .encode(writer);
+                writer.extend_from_slice(data);
             }
             Self::Enumerated(x) => {
                 x.encode(writer);

--- a/src/common/helper.rs
+++ b/src/common/helper.rs
@@ -68,31 +68,6 @@ fn get_tagged_body_internal<'a>(
     }
 }
 
-pub fn encode_i16(writer: &mut Writer, value: i16) {
-    writer.extend_from_slice(&value.to_be_bytes());
-}
-
-pub fn encode_i32(writer: &mut Writer, value: i32) {
-    writer.extend_from_slice(&value.to_be_bytes());
-}
-
-pub fn encode_u16(writer: &mut Writer, value: u16) {
-    writer.extend_from_slice(&value.to_be_bytes());
-}
-
-pub fn encode_u24(writer: &mut Writer, value: u32) {
-    let slice = &value.to_be_bytes();
-    writer.extend_from_slice(&slice[..3]);
-}
-
-pub fn encode_u32(writer: &mut Writer, value: u32) {
-    writer.extend_from_slice(&value.to_be_bytes());
-}
-
-pub fn encode_u64(writer: &mut Writer, value: u64) {
-    writer.extend_from_slice(&value.to_be_bytes());
-}
-
 pub fn encode_context_object_id(writer: &mut Writer, tag_number: u8, object_id: &ObjectId) {
     let tag = Tag::new(TagNumber::ContextSpecific(tag_number), ObjectId::LEN);
     tag.encode(writer);
@@ -145,14 +120,6 @@ pub fn encode_closing_tag(writer: &mut Writer, tag_number: u8) {
     }
 }
 
-pub fn encode_context_unsigned(writer: &mut Writer, tag_number: u8, value: u32) {
-    let len = get_len_u64(value as u64);
-
-    let tag = Tag::new(TagNumber::ContextSpecific(tag_number), len);
-    tag.encode(writer);
-    encode_unsigned(writer, len, value as u64);
-}
-
 pub fn decode_context_property_id(
     reader: &mut Reader,
     buf: &[u8],
@@ -170,33 +137,63 @@ pub fn decode_context_property_id(
     Ok(property_id)
 }
 
-pub fn encode_context_enumerated(writer: &mut Writer, tag_number: u8, property_id: &PropertyId) {
-    let value = *property_id as u32;
-    let len = get_len_u64(value as u64);
-
-    let tag = Tag::new(TagNumber::ContextSpecific(tag_number), len);
-    tag.encode(writer);
-    encode_unsigned(writer, len, value as u64);
+fn encode_unsigned_impl(writer: &mut Writer, tag_number: TagNumber, value: impl Into<u64>) {
+    let data = value.into().to_be_bytes();
+    let skip = data.into_iter().take_while(|&x| x == 0).count();
+    let data = &data[skip..];
+    Tag::new(tag_number, data.len() as u32)
+        .encode(writer);
+    writer.extend_from_slice(data);
 }
 
-pub fn encode_application_unsigned(writer: &mut Writer, value: u64) {
-    let len = get_len_u64(value);
-    Tag::new(
-        TagNumber::Application(ApplicationTagNumber::UnsignedInt),
-        len,
-    )
-    .encode(writer);
-    encode_unsigned(writer, len, value);
+pub fn encode_unsigned(writer: &mut Writer, context_tag: Option<u8>, value: impl Into<u64>) {
+    let tag_number = context_tag.map(TagNumber::ContextSpecific)
+        .unwrap_or(TagNumber::Application(ApplicationTagNumber::UnsignedInt));
+    encode_unsigned_impl(writer, tag_number, value);
+}
+
+pub fn encode_signed(writer: &mut Writer, context_tag: Option<u8>, value: impl Into<i64>) {
+    let data = value.into().to_be_bytes();
+    let leading_zeros = data.into_iter().take_while(|&x| x == 0).count();
+    let leading_signs = data.into_iter().take_while(|&x| x == 0xFF).count();
+    let skip = usize::max(leading_zeros, leading_signs);
+    let data = &data[skip..];
+
+    let tag_number = context_tag.map(TagNumber::ContextSpecific)
+        .unwrap_or(TagNumber::Application(ApplicationTagNumber::SignedInt));
+    Tag::new(tag_number, data.len() as u32)
+        .encode(writer);
+    writer.extend_from_slice(data);
+}
+
+pub fn encode_enumerated(writer: &mut Writer, value: impl Into<u64>, context_tag: Option<u8>) {
+    let tag_number = context_tag.map(TagNumber::ContextSpecific)
+        .unwrap_or(TagNumber::Application(ApplicationTagNumber::Enumerated));
+    encode_unsigned_impl(writer, tag_number, value);
+}
+
+pub fn encode_application_unsigned(writer: &mut Writer, value: impl Into<u64>) {
+    encode_unsigned(writer, None, value);
+}
+
+pub fn encode_context_unsigned(writer: &mut Writer, tag_number: u8, value: impl Into<u64>) {
+    encode_unsigned(writer, Some(tag_number), value);
+}
+
+pub fn encode_application_signed(writer: &mut Writer, value: impl Into<i64>) {
+    encode_signed(writer, None, value);
+}
+
+pub fn encode_context_signed(writer: &mut Writer, tag_number: u8, value: impl Into<i64>) {
+    encode_signed(writer, Some(tag_number), value);
 }
 
 pub fn encode_application_enumerated(writer: &mut Writer, value: u32) {
-    let len = get_len_u32(value);
-    let tag = Tag::new(
-        TagNumber::Application(ApplicationTagNumber::Enumerated),
-        len,
-    );
-    tag.encode(writer);
-    encode_unsigned(writer, len, value as u64);
+    encode_enumerated(writer, value, None);
+}
+
+pub fn encode_context_enumerated(writer: &mut Writer, tag_number: u8, property_id: &PropertyId) {
+    encode_enumerated(writer, *property_id as u32, Some(tag_number))
 }
 
 pub fn encode_application_object_id(writer: &mut Writer, object_id: &ObjectId) {
@@ -208,119 +205,25 @@ pub fn encode_application_object_id(writer: &mut Writer, object_id: &ObjectId) {
     object_id.encode(writer);
 }
 
-pub fn encode_application_signed(writer: &mut Writer, value: i32) {
-    let mut len = get_len_i32(value);
-    len = if len == 3 { 4 } else { len }; // we don't bother with 3 byte integers (just save it as a 4 byte integer)
-    Tag::new(TagNumber::Application(ApplicationTagNumber::SignedInt), len).encode(writer);
-    encode_signed(writer, len, value);
-}
-
-pub fn get_len_u32(value: u32) -> u32 {
-    if value < 0x100 {
-        1
-    } else if value < 0x10000 {
-        2
-    } else if value < 0x1000000 {
-        3
-    } else {
-        4
-    }
-}
-
-fn get_len_u64(value: u64) -> u32 {
-    if value < 0x100 {
-        1
-    } else if value < 0x10000 {
-        2
-    } else if value < 0x1000000 {
-        3
-    } else if value < 0x100000000 {
-        4
-    } else {
-        8
-    }
-}
-
-fn get_len_i32(value: i32) -> u32 {
-    if (-128..128).contains(&value) {
-        1
-    } else if (-32768..32768).contains(&value) {
-        2
-    } else if (-8388608..8388608).contains(&value) {
-        3
-    } else {
-        4
-    }
-}
-
 pub fn decode_unsigned(len: u32, reader: &mut Reader, buf: &[u8]) -> Result<u64, Error> {
-    let value = match len {
-        1 => reader.read_byte(buf)? as u64,
-        2 => u16::from_be_bytes(reader.read_bytes(buf)?) as u64,
-        3 => {
-            let bytes: [u8; 3] = reader.read_bytes(buf)?;
-            let mut tmp: [u8; 4] = [0; 4];
-            tmp[1..].copy_from_slice(&bytes);
-            u32::from_be_bytes(tmp) as u64
-        }
-        4 => u32::from_be_bytes(reader.read_bytes(buf)?) as u64,
-        8 => u64::from_be_bytes(reader.read_bytes(buf)?),
-        x => return Err(Error::Length(("unsigned len must be between 1 and 8", x))),
-    };
-
-    Ok(value)
-}
-
-pub fn _decode_u32(len: u32, reader: &mut Reader, buf: &[u8]) -> Result<u32, Error> {
-    let value = match len {
-        1 => reader.read_byte(buf)? as u32,
-        2 => u16::from_be_bytes(reader.read_bytes(buf)?) as u32,
-        3 => {
-            let bytes: [u8; 3] = reader.read_bytes(buf)?;
-            let mut tmp: [u8; 4] = [0; 4];
-            tmp[1..].copy_from_slice(&bytes);
-            u32::from_be_bytes(tmp)
-        }
-        4 => u32::from_be_bytes(reader.read_bytes(buf)?),
-        x => return Err(Error::Length(("u32 len must be between 1 and 4", x))),
-    };
-
-    Ok(value)
-}
-
-pub fn decode_signed(len: u32, reader: &mut Reader, buf: &[u8]) -> Result<i32, Error> {
-    let value = match len {
-        1 => reader.read_byte(buf)? as i32,
-        2 => u16::from_be_bytes(reader.read_bytes(buf)?) as i32,
-        3 => {
-            let bytes: [u8; 3] = reader.read_bytes(buf)?;
-            let mut tmp: [u8; 4] = [0; 4];
-            tmp[1..].copy_from_slice(&bytes);
-            i32::from_be_bytes(tmp)
-        }
-        4 => i32::from_be_bytes(reader.read_bytes(buf)?),
-        x => return Err(Error::Length(("signed len must be between 1 and 4", x))),
-    };
-
-    Ok(value)
-}
-
-pub fn encode_unsigned(writer: &mut Writer, len: u32, value: u64) {
-    match len {
-        1 => writer.push(value as u8),
-        2 => encode_u16(writer, value as u16),
-        3 => encode_u24(writer, value as u32),
-        4 => encode_u32(writer, value as u32),
-        8 => encode_u64(writer, value),
-        _ => unreachable!(),
+    if len > 8 {
+        return Err(Error::Length(("integers bigger than 64 bits bytes are not supported", len)));
     }
+    let len = len as usize;
+    let mut bytes = [0; 8];
+    bytes[..len].copy_from_slice(reader.read_slice(len, buf)?);
+    let value = u64::from_be_bytes(bytes) >> (8 * (8 - len));
+    Ok(value)
 }
 
-pub fn encode_signed(writer: &mut Writer, len: u32, value: i32) {
-    match len {
-        1 => writer.push(value as u8),
-        2 => encode_i16(writer, value as i16),
-        4 => encode_i32(writer, value),
-        _ => unreachable!(),
+pub fn decode_signed(len: u32, reader: &mut Reader, buf: &[u8]) -> Result<i64, Error> {
+    if len > 8 {
+        return Err(Error::Length(("integers bigger than 64 bits are not supported", len)));
     }
+    // Read into the most significant bits, then do a right shift to get sign extension for negative integers.
+    let len = len as usize;
+    let mut bytes = [0; 8];
+    bytes[..len].copy_from_slice(reader.read_slice(len, buf)?);
+    let value = i64::from_be_bytes(bytes) >> (8 * (8 - len));
+    Ok(value)
 }

--- a/src/common/helper.rs
+++ b/src/common/helper.rs
@@ -138,8 +138,9 @@ pub fn decode_context_property_id(
 }
 
 fn encode_unsigned_impl(writer: &mut Writer, tag_number: TagNumber, value: impl Into<u64>) {
-    let data = value.into().to_be_bytes();
-    let skip = data.into_iter().take_while(|&x| x == 0).count();
+    let value = value.into();
+    let skip = count_skippable_zero_bytes(value);
+    let data = value.to_be_bytes();
     let data = &data[skip..];
     Tag::new(tag_number, data.len() as u32)
         .encode(writer);
@@ -153,10 +154,12 @@ pub fn encode_unsigned(writer: &mut Writer, context_tag: Option<u8>, value: impl
 }
 
 pub fn encode_signed(writer: &mut Writer, context_tag: Option<u8>, value: impl Into<i64>) {
-    let data = value.into().to_be_bytes();
-    let leading_zeros = data.into_iter().take_while(|&x| x == 0).count();
-    let leading_signs = data.into_iter().take_while(|&x| x == 0xFF).count();
-    let skip = usize::max(leading_zeros, leading_signs);
+    let value = value.into();
+    let skip = match u64::try_from(value) {
+        Ok(non_negative) => count_skippable_zero_bytes(non_negative),
+        Err(_) => count_skippable_sign_bytes(value),
+    };
+    let data = value.to_be_bytes();
     let data = &data[skip..];
 
     let tag_number = context_tag.map(TagNumber::ContextSpecific)
@@ -182,10 +185,6 @@ pub fn encode_context_unsigned(writer: &mut Writer, tag_number: u8, value: impl 
 
 pub fn encode_application_signed(writer: &mut Writer, value: impl Into<i64>) {
     encode_signed(writer, None, value);
-}
-
-pub fn encode_context_signed(writer: &mut Writer, tag_number: u8, value: impl Into<i64>) {
-    encode_signed(writer, Some(tag_number), value);
 }
 
 pub fn encode_application_enumerated(writer: &mut Writer, value: u32) {
@@ -226,4 +225,76 @@ pub fn decode_signed(len: u32, reader: &mut Reader, buf: &[u8]) -> Result<i64, E
     bytes[..len].copy_from_slice(reader.read_slice(len, buf)?);
     let value = i64::from_be_bytes(bytes) >> (8 * (8 - len));
     Ok(value)
+}
+fn count_skippable_zero_bytes(data: u64) -> usize {
+    if data == 0 {
+        7
+    } else {
+        let skippable_bits = data.leading_zeros();
+        let skippable_bytes = skippable_bits / 8;
+        skippable_bytes as usize
+    }
+}
+
+fn count_skippable_sign_bytes(data: i64) -> usize {
+    if data >= 0 {
+        0
+    } else {
+        // We must leave at-least 1 sign bit.
+        let skippable_bits = data.leading_ones() - 1;
+        let skippable_bytes = skippable_bits / 8;
+        skippable_bytes as usize
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_count_skippable_zero_bytes() {
+        assert_eq!(count_skippable_zero_bytes(0x00), 7);
+
+        assert_eq!(count_skippable_zero_bytes(0x0000_0000_0000_0001), 7);
+        assert_eq!(count_skippable_zero_bytes(0x0000_0000_0000_00FF), 7);
+        assert_eq!(count_skippable_zero_bytes(0x0000_0000_0000_01FF), 6);
+        assert_eq!(count_skippable_zero_bytes(0x0000_0000_0000_FFFF), 6);
+        assert_eq!(count_skippable_zero_bytes(0x0000_0000_0001_FFFF), 5);
+        assert_eq!(count_skippable_zero_bytes(0x0000_0000_00FF_FFFF), 5);
+        assert_eq!(count_skippable_zero_bytes(0x0000_0000_01FF_FFFF), 4);
+        assert_eq!(count_skippable_zero_bytes(0x0000_0000_FFFF_FFFF), 4);
+        assert_eq!(count_skippable_zero_bytes(0x0000_0001_FFFF_FFFF), 3);
+        assert_eq!(count_skippable_zero_bytes(0x0000_00FF_FFFF_FFFF), 3);
+        assert_eq!(count_skippable_zero_bytes(0x0000_01FF_FFFF_FFFF), 2);
+        assert_eq!(count_skippable_zero_bytes(0x0000_FFFF_FFFF_FFFF), 2);
+        assert_eq!(count_skippable_zero_bytes(0x0001_FFFF_FFFF_FFFF), 1);
+        assert_eq!(count_skippable_zero_bytes(0x00FF_FFFF_FFFF_FFFF), 1);
+        assert_eq!(count_skippable_zero_bytes(0x01FF_FFFF_FFFF_FFFF), 0);
+        assert_eq!(count_skippable_zero_bytes(0xFFFF_FFFF_FFFF_FFFF), 0);
+    }
+
+    #[test]
+    fn test_count_skippable_sign_bytes() {
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_FFFF_FFFF_FFFF_u64 as i64), 7);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_FFFF_FFFF_FF80_u64 as i64), 7);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_FFFF_FFFF_FF7F_u64 as i64), 6);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_FFFF_FFFF_8000_u64 as i64), 6);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_FFFF_FFFF_7FFF_u64 as i64), 5);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_FFFF_FF80_0000_u64 as i64), 5);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_FFFF_FF7F_FFFF_u64 as i64), 4);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_FFFF_8000_0000_u64 as i64), 4);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_FFFF_7FFF_FFFF_u64 as i64), 3);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_FF80_0000_0000_u64 as i64), 3);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_FF7F_FFFF_FFFF_u64 as i64), 2);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_8000_0000_0000_u64 as i64), 2);
+        assert_eq!(count_skippable_sign_bytes(0xFFFF_7FFF_FFFF_FFFF_u64 as i64), 1);
+        assert_eq!(count_skippable_sign_bytes(0xFF80_0000_0000_0000_u64 as i64), 1);
+        assert_eq!(count_skippable_sign_bytes(0xFF7F_FFFF_FFFF_FFFF_u64 as i64), 0);
+        assert_eq!(count_skippable_sign_bytes(0x8000_0000_0000_0000_u64 as i64), 0);
+
+        // Also test some random non-negative values, even though those should not be passed to count_skippable_sign_bytes().
+        assert_eq!(count_skippable_sign_bytes(0x0000_0000_0000_0000_u64 as i64), 0);
+        assert_eq!(count_skippable_sign_bytes(0x7FFF_FFFF_FFFF_FFFF_u64 as i64), 0);
+        assert_eq!(count_skippable_sign_bytes(0x0000_FFFF_FFFF_FFFF_u64 as i64), 0);
+    }
 }

--- a/src/simple/mod.rs
+++ b/src/simple/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "alloc")]
+
 /// This module is meant to be a very basic way to interact with a BACnet IP network in a simple request / response manner
 /// It automatically links up requests with responses using an invoke_id which only really works when you send one request at a time.
 /// If you intend to fire off many simultaneous requests then you should keep track of invoke_ids and handle congestion and packet ordering yourself.


### PR DESCRIPTION
This PR adds a `SignedInt` and `UnsignedInt` variants for `ApplicationDataValueWrite` to support writing integer values.