### PR TITLE
Unifiy application data values

### DIFF
--- a/examples/update_schedule.rs
+++ b/examples/update_schedule.rs
@@ -6,7 +6,7 @@ use clap::{command, Parser};
 use common::MySocket;
 use embedded_bacnet::{
     application_protocol::{
-        primitives::data_value::{ApplicationDataValue, ApplicationDataValueWrite},
+        primitives::data_value::ApplicationDataValue,
         services::{
             read_property_multiple::{
                 PropertyValue, ReadPropertyMultiple, ReadPropertyMultipleObject,
@@ -57,11 +57,11 @@ async fn main() -> Result<(), BacnetError<MySocket>> {
         PropertyId::PropWeeklySchedule,
         None,
         None,
-        ApplicationDataValueWrite::WeeklySchedule(weekly_schedule),
+        ApplicationDataValue::WeeklySchedule(weekly_schedule),
     );
 
-    let ack = bacnet.write_property(&mut buf, request).await?;
-    println!("Write ack: {:?}", ack);
+    let () = bacnet.write_property(&mut buf, request).await?;
+    println!("Write ack: OK");
 
     Ok(())
 }

--- a/examples/update_schedule_no_alloc.rs
+++ b/examples/update_schedule_no_alloc.rs
@@ -10,7 +10,7 @@ use crate::common::{get_bacnet_socket, MySocket};
 use clap::{command, Parser};
 use embedded_bacnet::{
     application_protocol::{
-        primitives::data_value::{ApplicationDataValue, ApplicationDataValueWrite},
+        primitives::data_value::ApplicationDataValue,
         services::{
             read_property_multiple::{
                 PropertyValue, ReadPropertyMultiple, ReadPropertyMultipleObject,
@@ -124,11 +124,11 @@ async fn main() -> Result<(), BacnetError<MySocket>> {
         PropertyId::PropWeeklySchedule,
         None,
         None,
-        ApplicationDataValueWrite::WeeklySchedule(weekly_schedule),
+        ApplicationDataValue::WeeklySchedule(weekly_schedule),
     );
 
-    let ack = bacnet.write_property(&mut buf, request).await?;
-    println!("Write ack: {:?}", ack);
+    let () = bacnet.write_property(&mut buf, request).await?;
+    println!("Write ack: OK");
 
     Ok(())
 }

--- a/examples/write_property.rs
+++ b/examples/write_property.rs
@@ -5,7 +5,7 @@ use clap::{command, Parser};
 use common::MySocket;
 use embedded_bacnet::{
     application_protocol::{
-        primitives::data_value::{ApplicationDataValueWrite, Enumerated},
+        primitives::data_value::{ApplicationDataValue, Enumerated},
         services::write_property::WriteProperty,
     },
     common::{
@@ -40,7 +40,7 @@ async fn main() -> Result<(), BacnetError<MySocket>> {
         PropertyId::PropPresentValue,
         None,
         None,
-        ApplicationDataValueWrite::Enumerated(Enumerated::Binary(Binary::On)),
+        ApplicationDataValue::Enumerated(Enumerated::Binary(Binary::On)),
     );
     bacnet.write_property(&mut buf, request).await?;
     println!("Write ON to BinaryValue no. 3 successful");

--- a/src/application_protocol/primitives/data_value.rs
+++ b/src/application_protocol/primitives/data_value.rs
@@ -3,7 +3,10 @@ use core::{fmt::Display, str::from_utf8};
 use crate::common::{
     daily_schedule::WeeklySchedule,
     error::Error,
-    helper::{decode_signed, decode_unsigned, encode_application_enumerated, encode_application_signed, encode_application_unsigned},
+    helper::{
+        decode_signed, decode_unsigned, encode_application_enumerated, encode_application_signed,
+        encode_application_unsigned,
+    },
     io::{Reader, Writer},
     object_id::{ObjectId, ObjectType},
     property_id::PropertyId,
@@ -39,7 +42,6 @@ pub enum ApplicationDataValue<'a> {
 
 #[deprecated(note = "use ApplicationDataValue")]
 pub type ApplicationDataValueWrite<'a> = ApplicationDataValue<'a>;
-
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -387,12 +389,20 @@ impl<'a> ApplicationDataValue<'a> {
             .encode(writer),
             ApplicationDataValue::Real(x) => {
                 let bytes = x.to_be_bytes();
-                Tag::new(TagNumber::Application(ApplicationTagNumber::Real), bytes.len() as u32).encode(writer);
+                Tag::new(
+                    TagNumber::Application(ApplicationTagNumber::Real),
+                    bytes.len() as u32,
+                )
+                .encode(writer);
                 writer.extend_from_slice(&bytes);
             }
             ApplicationDataValue::Double(x) => {
                 let bytes = x.to_be_bytes();
-                Tag::new(TagNumber::Application(ApplicationTagNumber::Real), bytes.len() as u32).encode(writer);
+                Tag::new(
+                    TagNumber::Application(ApplicationTagNumber::Real),
+                    bytes.len() as u32,
+                )
+                .encode(writer);
                 writer.extend_from_slice(&bytes);
             }
             ApplicationDataValue::Date(x) => {
@@ -443,12 +453,8 @@ impl<'a> ApplicationDataValue<'a> {
             ApplicationDataValue::BitString(x) => {
                 x.encode_application(writer);
             }
-            ApplicationDataValue::UnsignedInt(x) => {
-                encode_application_unsigned(writer, *x)
-            }
-            ApplicationDataValue::SignedInt(x) => {
-                encode_application_signed(writer, *x)
-            }
+            ApplicationDataValue::UnsignedInt(x) => encode_application_unsigned(writer, *x),
+            ApplicationDataValue::SignedInt(x) => encode_application_signed(writer, *x),
             ApplicationDataValue::WeeklySchedule(x) => {
                 // no application tag required for weekly schedule
                 x.encode(writer);
@@ -481,16 +487,18 @@ impl<'a> ApplicationDataValue<'a> {
         };
 
         match tag_num {
-            ApplicationTagNumber::Real => {
-                match tag.value {
-                    4 => Ok(ApplicationDataValue::Real(f32::from_be_bytes(reader.read_bytes(buf)?))),
-                    8 => Ok(ApplicationDataValue::Double(f64::from_be_bytes(reader.read_bytes(buf)?))),
-                    _ => Err(Error::Length((
-                        "real tag should have length of 4 or 8",
-                        tag.value,
-                    ))),
-                }
-            }
+            ApplicationTagNumber::Real => match tag.value {
+                4 => Ok(ApplicationDataValue::Real(f32::from_be_bytes(
+                    reader.read_bytes(buf)?,
+                ))),
+                8 => Ok(ApplicationDataValue::Double(f64::from_be_bytes(
+                    reader.read_bytes(buf)?,
+                ))),
+                _ => Err(Error::Length((
+                    "real tag should have length of 4 or 8",
+                    tag.value,
+                ))),
+            },
             ApplicationTagNumber::ObjectId => {
                 let object_id = ObjectId::decode(tag.value, reader, buf)?;
                 Ok(ApplicationDataValue::ObjectId(object_id))

--- a/src/application_protocol/primitives/data_value.rs
+++ b/src/application_protocol/primitives/data_value.rs
@@ -480,8 +480,14 @@ impl<'a> ApplicationDataValue<'a> {
             )
             .encode(writer),
             ApplicationDataValue::Real(x) => {
-                Tag::new(TagNumber::Application(ApplicationTagNumber::Real), 4).encode(writer);
-                writer.extend_from_slice(&x.to_be_bytes());
+                let bytes = x.to_be_bytes();
+                Tag::new(TagNumber::Application(ApplicationTagNumber::Real), bytes.len() as u32).encode(writer);
+                writer.extend_from_slice(&bytes);
+            }
+            ApplicationDataValue::Double(x) => {
+                let bytes = x.to_be_bytes();
+                Tag::new(TagNumber::Application(ApplicationTagNumber::Real), bytes.len() as u32).encode(writer);
+                writer.extend_from_slice(&bytes);
             }
             ApplicationDataValue::Date(x) => {
                 Tag::new(
@@ -541,8 +547,6 @@ impl<'a> ApplicationDataValue<'a> {
                 // no application tag required for weekly schedule
                 x.encode(writer);
             }
-
-            x => todo!("{:?}", x),
         };
     }
 
@@ -566,15 +570,14 @@ impl<'a> ApplicationDataValue<'a> {
 
         match tag_num {
             ApplicationTagNumber::Real => {
-                if tag.value != 4 {
-                    return Err(Error::Length((
-                        "real tag should have length of 4",
+                match tag.value {
+                    4 => Ok(ApplicationDataValue::Real(f32::from_be_bytes(reader.read_bytes(buf)?))),
+                    8 => Ok(ApplicationDataValue::Double(f64::from_be_bytes(reader.read_bytes(buf)?))),
+                    _ => Err(Error::Length((
+                        "real tag should have length of 4 or 8",
                         tag.value,
-                    )));
+                    ))),
                 }
-                Ok(ApplicationDataValue::Real(f32::from_be_bytes(
-                    reader.read_bytes(buf)?,
-                )))
             }
             ApplicationTagNumber::ObjectId => {
                 let object_id = ObjectId::decode(tag.value, reader, buf)?;

--- a/src/application_protocol/primitives/data_value.rs
+++ b/src/application_protocol/primitives/data_value.rs
@@ -37,16 +37,9 @@ pub enum ApplicationDataValue<'a> {
     WeeklySchedule(WeeklySchedule<'a>),
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum ApplicationDataValueWrite<'a> {
-    Boolean(bool),
-    UnsignedInt(u64),
-    SignedInt(i64),
-    Enumerated(Enumerated),
-    Real(f32),
-    WeeklySchedule(WeeklySchedule<'a>),
-}
+#[deprecated(note = "use ApplicationDataValue")]
+pub type ApplicationDataValueWrite<'a> = ApplicationDataValue<'a>;
+
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -384,93 +377,6 @@ impl<'a> OctetString<'a> {
     }
 }
 
-impl<'a> ApplicationDataValueWrite<'a> {
-    #[cfg_attr(feature = "alloc", bacnet_macros::remove_lifetimes_from_fn_args)]
-    pub fn decode(
-        object_id: &ObjectId,
-        property_id: &PropertyId,
-        reader: &mut Reader,
-        buf: &'a [u8],
-    ) -> Result<Self, Error> {
-        match property_id {
-            PropertyId::PropWeeklySchedule => {
-                let weekly_schedule = WeeklySchedule::decode(reader, buf)?;
-                Ok(Self::WeeklySchedule(weekly_schedule))
-            }
-            _ => {
-                let tag = Tag::decode(reader, buf)?;
-                match tag.number {
-                    TagNumber::Application(ApplicationTagNumber::Boolean) => {
-                        Ok(Self::Boolean(tag.value > 0))
-                    }
-                    TagNumber::Application(ApplicationTagNumber::Real) => {
-                        if tag.value != 4 {
-                            return Err(Error::Length((
-                                "real tag should have length of 4",
-                                tag.value,
-                            )));
-                        }
-                        let bytes = reader.read_bytes(buf)?;
-                        Ok(Self::Real(f32::from_be_bytes(bytes)))
-                    }
-                    TagNumber::Application(ApplicationTagNumber::Enumerated) => {
-                        let value = decode_enumerated(object_id, property_id, &tag, reader, buf)?;
-                        Ok(Self::Enumerated(value))
-                    }
-                    TagNumber::Application(ApplicationTagNumber::UnsignedInt) => {
-                        Ok(Self::UnsignedInt(decode_unsigned(tag.value, reader, buf)?))
-
-                    }
-                    TagNumber::Application(ApplicationTagNumber::SignedInt) => {
-                        let len = tag.value as usize;
-                        if len > 8 {
-                            return Err(Error::Length(("integers bigger than 64 bits are not supported", tag.value)));
-                        }
-                        // Read into the most significant bits, then do a right shift to get sign extension for negative integers.
-                        let mut bytes = [0; 8];
-                        bytes[..len].copy_from_slice(reader.read_slice(len, buf)?);
-                        let value = i64::from_be_bytes(bytes) >> (8 * (8 - len));
-                        Ok(Self::SignedInt(value))
-
-                    }
-                    tag_number => Err(Error::TagNotSupported((
-                        "ApplicationDataValueWrite decode",
-                        tag_number,
-                    ))),
-                }
-            }
-        }
-    }
-
-    pub fn encode(&self, writer: &mut Writer) {
-        match self {
-            Self::Boolean(x) => {
-                let len = 1;
-                let tag = Tag::new(TagNumber::Application(ApplicationTagNumber::Boolean), len);
-                tag.encode(writer);
-                let value = if *x { 1_u8 } else { 0_u8 };
-                writer.push(value)
-            }
-            Self::Real(x) => {
-                let len = 4;
-                let tag = Tag::new(TagNumber::Application(ApplicationTagNumber::Real), len);
-                tag.encode(writer);
-                writer.extend_from_slice(&f32::to_be_bytes(*x))
-            }
-            Self::UnsignedInt(x) => {
-                encode_application_unsigned(writer, *x);
-            }
-            Self::SignedInt(x) => {
-                encode_application_signed(writer, *x);
-            }
-            Self::Enumerated(x) => {
-                x.encode(writer);
-            }
-            Self::WeeklySchedule(x) => x.encode(writer),
-        }
-    }
-}
-
 impl<'a> ApplicationDataValue<'a> {
     pub fn encode(&self, writer: &mut Writer) {
         match self {
@@ -552,12 +458,18 @@ impl<'a> ApplicationDataValue<'a> {
 
     #[cfg_attr(feature = "alloc", bacnet_macros::remove_lifetimes_from_fn_args)]
     pub fn decode(
-        tag: &Tag,
         object_id: &ObjectId,
         property_id: &PropertyId,
         reader: &mut Reader,
         buf: &'a [u8],
     ) -> Result<Self, Error> {
+        // Weekly schedule not tagged.
+        if *property_id == PropertyId::PropWeeklySchedule {
+            return Ok(Self::WeeklySchedule(WeeklySchedule::decode(reader, buf)?));
+        }
+
+        let tag = Tag::decode(reader, buf)?;
+
         let tag_num = match &tag.number {
             TagNumber::Application(x) => x,
             unknown => {
@@ -592,7 +504,7 @@ impl<'a> ApplicationDataValue<'a> {
                 Ok(ApplicationDataValue::OctetString(date))
             }
             ApplicationTagNumber::Enumerated => {
-                let value = decode_enumerated(object_id, property_id, tag, reader, buf)?;
+                let value = decode_enumerated(object_id, property_id, &tag, reader, buf)?;
                 Ok(ApplicationDataValue::Enumerated(value))
             }
             ApplicationTagNumber::BitString => {

--- a/src/application_protocol/primitives/data_value.rs
+++ b/src/application_protocol/primitives/data_value.rs
@@ -29,6 +29,7 @@ pub enum ApplicationDataValue<'a> {
     Time(Time),
     ObjectId(ObjectId),
     CharacterString(CharacterString<'a>),
+    OctetString(OctetString<'a>),
     Enumerated(Enumerated),
     BitString(BitString<'a>),
     UnsignedInt(u64),
@@ -174,6 +175,24 @@ pub struct CharacterString<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CharacterString<'a> {
     pub inner: String,
+    #[cfg_attr(feature = "serde", serde(skip_serializing))]
+    _phantom: &'a Phantom,
+}
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OctetString<'a> {
+    pub inner: &'a [u8],
+}
+
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OctetString<'a> {
+    pub inner: Vec<u8>,
     #[cfg_attr(feature = "serde", serde(skip_serializing))]
     _phantom: &'a Phantom,
 }
@@ -338,7 +357,30 @@ impl<'a> CharacterString<'a> {
             Error::InvalidValue("CharacterString bytes are not a valid utf8 string")
         })?;
 
-        Ok(CharacterString::new(inner))
+        Ok(Self::new(inner))
+    }
+}
+
+impl<'a> OctetString<'a> {
+    #[cfg(not(feature = "alloc"))]
+    pub fn new(inner: &'a [u8]) -> Self {
+        Self { inner }
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn new(inner: &[u8]) -> Self {
+        use crate::common::spooky::PHANTOM;
+
+        Self {
+            inner: inner.into(),
+            _phantom: &PHANTOM,
+        }
+    }
+
+    #[cfg_attr(feature = "alloc", bacnet_macros::remove_lifetimes_from_fn_args)]
+    pub fn decode(len: u32, reader: &mut Reader, buf: &'a [u8]) -> Result<Self, Error> {
+        let slice = reader.read_slice(len as usize, buf)?;
+        Ok(Self::new(slice))
     }
 }
 
@@ -475,6 +517,14 @@ impl<'a> ApplicationDataValue<'a> {
                 writer.push(0); // utf8 encoding
                 writer.extend_from_slice(utf8_encoded);
             }
+            ApplicationDataValue::OctetString(x) => {
+                Tag::new(
+                    TagNumber::Application(ApplicationTagNumber::OctetString),
+                    x.inner.len() as u32,
+                )
+                .encode(writer);
+                writer.extend_from_slice(&x.inner);
+            }
             ApplicationDataValue::Enumerated(x) => {
                 x.encode(writer);
             }
@@ -533,6 +583,10 @@ impl<'a> ApplicationDataValue<'a> {
             ApplicationTagNumber::CharacterString => {
                 let text = CharacterString::decode(tag.value, reader, buf)?;
                 Ok(ApplicationDataValue::CharacterString(text))
+            }
+            ApplicationTagNumber::OctetString => {
+                let date = OctetString::decode(tag.value, reader, buf)?;
+                Ok(ApplicationDataValue::OctetString(date))
             }
             ApplicationTagNumber::Enumerated => {
                 let value = decode_enumerated(object_id, property_id, tag, reader, buf)?;

--- a/src/application_protocol/services/change_of_value.rs
+++ b/src/application_protocol/services/change_of_value.rs
@@ -97,8 +97,7 @@ impl<'a> PropertyResult<'a> {
             TagNumber::ContextSpecificOpening(2),
             "CovNotification next expected value opening tag",
         )?;
-        let tag = Tag::decode(reader, buf)?;
-        let value = ApplicationDataValue::decode(&tag, object_id, &property_id, reader, buf)?;
+        let value = ApplicationDataValue::decode(object_id, &property_id, reader, buf)?;
         Tag::decode_expected(
             reader,
             buf,

--- a/src/application_protocol/services/read_property.rs
+++ b/src/application_protocol/services/read_property.rs
@@ -208,9 +208,8 @@ impl<'a> ReadPropertyAck<'a> {
                 })
             }
             property_id => {
-                let tag = Tag::decode(&mut reader, buf)?;
                 let value =
-                    ApplicationDataValue::decode(&tag, &object_id, &property_id, &mut reader, buf)?;
+                    ApplicationDataValue::decode(&object_id, &property_id, &mut reader, buf)?;
                 let property_value = ReadPropertyValue::ApplicationDataValue(value);
 
                 Ok(Self {

--- a/src/application_protocol/services/read_property_multiple.rs
+++ b/src/application_protocol/services/read_property_multiple.rs
@@ -321,8 +321,7 @@ impl<'a> PropertyResult<'a> {
                     ))
                 }
                 property_id => {
-                    let value =
-                        ApplicationDataValue::decode(object_id, property_id, reader, buf)?;
+                    let value = ApplicationDataValue::decode(object_id, property_id, reader, buf)?;
                     Ok(PropertyValue::PropValue(value))
                 }
             }

--- a/src/application_protocol/services/read_property_multiple.rs
+++ b/src/application_protocol/services/read_property_multiple.rs
@@ -321,9 +321,8 @@ impl<'a> PropertyResult<'a> {
                     ))
                 }
                 property_id => {
-                    let tag = Tag::decode(reader, buf)?;
                     let value =
-                        ApplicationDataValue::decode(&tag, object_id, property_id, reader, buf)?;
+                        ApplicationDataValue::decode(object_id, property_id, reader, buf)?;
                     Ok(PropertyValue::PropValue(value))
                 }
             }

--- a/src/application_protocol/services/write_property.rs
+++ b/src/application_protocol/services/write_property.rs
@@ -1,5 +1,5 @@
 use crate::{
-    application_protocol::primitives::data_value::ApplicationDataValueWrite,
+    application_protocol::primitives::data_value::ApplicationDataValue,
     common::{
         error::Error,
         helper::{
@@ -22,7 +22,7 @@ pub struct WriteProperty<'a> {
     pub property_id: PropertyId,
     pub priority: Option<u8>,
     pub array_index: Option<u32>,
-    pub value: ApplicationDataValueWrite<'a>,
+    pub value: ApplicationDataValue<'a>,
 }
 
 impl<'a> WriteProperty<'a> {
@@ -38,7 +38,7 @@ impl<'a> WriteProperty<'a> {
         property_id: PropertyId,
         priority: Option<u8>,
         array_index: Option<u32>,
-        value: ApplicationDataValueWrite<'a>,
+        value: ApplicationDataValue<'a>,
     ) -> Self {
         Self {
             object_id,
@@ -82,7 +82,7 @@ impl<'a> WriteProperty<'a> {
             "WriteProperty decode value",
             TagNumber::ContextSpecificOpening(Self::TAG_VALUE),
         )?;
-        let value = ApplicationDataValueWrite::decode(&object_id, &property_id, reader, buf)?;
+        let value = ApplicationDataValue::decode(&object_id, &property_id, reader, buf)?;
         Tag::decode_expected(
             reader,
             buf,

--- a/src/common/helper.rs
+++ b/src/common/helper.rs
@@ -142,13 +142,13 @@ fn encode_unsigned_impl(writer: &mut Writer, tag_number: TagNumber, value: impl 
     let skip = count_skippable_zero_bytes(value);
     let data = value.to_be_bytes();
     let data = &data[skip..];
-    Tag::new(tag_number, data.len() as u32)
-        .encode(writer);
+    Tag::new(tag_number, data.len() as u32).encode(writer);
     writer.extend_from_slice(data);
 }
 
 pub fn encode_unsigned(writer: &mut Writer, context_tag: Option<u8>, value: impl Into<u64>) {
-    let tag_number = context_tag.map(TagNumber::ContextSpecific)
+    let tag_number = context_tag
+        .map(TagNumber::ContextSpecific)
         .unwrap_or(TagNumber::Application(ApplicationTagNumber::UnsignedInt));
     encode_unsigned_impl(writer, tag_number, value);
 }
@@ -162,15 +162,16 @@ pub fn encode_signed(writer: &mut Writer, context_tag: Option<u8>, value: impl I
     let data = value.to_be_bytes();
     let data = &data[skip..];
 
-    let tag_number = context_tag.map(TagNumber::ContextSpecific)
+    let tag_number = context_tag
+        .map(TagNumber::ContextSpecific)
         .unwrap_or(TagNumber::Application(ApplicationTagNumber::SignedInt));
-    Tag::new(tag_number, data.len() as u32)
-        .encode(writer);
+    Tag::new(tag_number, data.len() as u32).encode(writer);
     writer.extend_from_slice(data);
 }
 
 pub fn encode_enumerated(writer: &mut Writer, value: impl Into<u64>, context_tag: Option<u8>) {
-    let tag_number = context_tag.map(TagNumber::ContextSpecific)
+    let tag_number = context_tag
+        .map(TagNumber::ContextSpecific)
         .unwrap_or(TagNumber::Application(ApplicationTagNumber::Enumerated));
     encode_unsigned_impl(writer, tag_number, value);
 }
@@ -206,7 +207,10 @@ pub fn encode_application_object_id(writer: &mut Writer, object_id: &ObjectId) {
 
 pub fn decode_unsigned(len: u32, reader: &mut Reader, buf: &[u8]) -> Result<u64, Error> {
     if len > 8 {
-        return Err(Error::Length(("integers bigger than 64 bits bytes are not supported", len)));
+        return Err(Error::Length((
+            "integers bigger than 64 bits bytes are not supported",
+            len,
+        )));
     }
     let len = len as usize;
     let mut bytes = [0; 8];
@@ -217,7 +221,10 @@ pub fn decode_unsigned(len: u32, reader: &mut Reader, buf: &[u8]) -> Result<u64,
 
 pub fn decode_signed(len: u32, reader: &mut Reader, buf: &[u8]) -> Result<i64, Error> {
     if len > 8 {
-        return Err(Error::Length(("integers bigger than 64 bits are not supported", len)));
+        return Err(Error::Length((
+            "integers bigger than 64 bits are not supported",
+            len,
+        )));
     }
     // Read into the most significant bits, then do a right shift to get sign extension for negative integers.
     let len = len as usize;
@@ -252,6 +259,7 @@ mod test {
     use super::*;
 
     #[test]
+    #[rustfmt::skip]
     fn test_count_skippable_zero_bytes() {
         assert_eq!(count_skippable_zero_bytes(0x00), 7);
 
@@ -274,6 +282,7 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_count_skippable_sign_bytes() {
         assert_eq!(count_skippable_sign_bytes(0xFFFF_FFFF_FFFF_FFFF_u64 as i64), 7);
         assert_eq!(count_skippable_sign_bytes(0xFFFF_FFFF_FFFF_FF80_u64 as i64), 7);


### PR DESCRIPTION
This PR continues on #9. The goal is to extend the supported data types further. For property reads, this now includes `f64` and byte strings. For property writes, it extends the supported types to everything also supported by property reads.

The PR:
* Adds a `AplicationDataValue::OctetString` variant for byte strings.
* Implements `ApplicationDataValue::Double` encoding/decoding.
* Removes `ApplicationDataValueWrite` and instead use `ApplicationDataValue` for both reads and writes.
  * As part of this, the `decode` function no longer takes a tag but decides by itself if it needs to read a tag first, based on the property ID (this behavior is taken from `ApplicationDataValueWrite::decode`).
  * For now there is still a deprecated alias under the name `ApplicationDataValueWrite`.
  * Examples also updated to no longer use `ApplicationDataValueWrite`.
* Formats the code (which I forgot in #9).

(no AI used)
